### PR TITLE
Safe strings

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -59,7 +59,7 @@ module InDisposal = Disposal.Make (struct
                   with Sys_error("Bad file descriptor") -> 103
   let default = Pervasives.close_in
 end)
- 
+
 module OutDisposal = Disposal.Make (struct
   type t      = out_channel
   let equal   = (==)
@@ -289,7 +289,7 @@ let string_of_channel c =
   let buf     = Buffer.create bufsize in
   let str     = String.make bufsize '\000' in
   let rec loop c =
-    match Pervasives.input c str 0 bufsize with
+    match Pervasives.input c Bytes.(of_string str) 0 bufsize with
     | 0 -> Buffer.contents buf
     | n -> Buffer.add_substring buf str 0 n;
            loop c in

--- a/lib/fitting.ml
+++ b/lib/fitting.ml
@@ -75,7 +75,7 @@ module Make(Shtream : AnyShtream.S) = struct
   (* This isn't reentrant. *)
   let copy_in_out =
     let buflen = 4096 in
-    let buf    = String.make buflen ' ' in
+    let buf    = Bytes.make buflen ' ' in
     let rec loop () =
       let count = Unix.read Unix.stdin buf 0 buflen in
       if count > 0 then begin

--- a/lib/iVar.ml
+++ b/lib/iVar.ml
@@ -33,7 +33,7 @@ let write rep v =
   kill rep;
   Unix.close rep.read_end;
   let buf = Marshal.to_string v [Marshal.Closures] in
-  ignore @@ Unix.write rep.write_end buf 0 (String.length buf);
+  ignore @@ Unix.write rep.write_end Bytes.(of_string buf) 0 (String.length buf);
   Unix.close rep.write_end
 
 let read rep =

--- a/lib/line.ml
+++ b/lib/line.ml
@@ -97,7 +97,7 @@ module Key_value = struct
     try Some (float_of_string (value line)) with Failure _ -> None
 
   let as_bool line =
-    match String.lowercase (value line) with
+    match String.lowercase_ascii (value line) with
     | "yes" | "y" | "1" | "true" | "on" | "enabled" | "enable" -> Some true
     | "no" | "n" | "0" | "false" | "off" | "disabled" | "disable" ->
       Some false

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -66,8 +66,8 @@ let rec make =
       let result = { content  = String.make n '\000';
                      before   = "";
                      after    = String.make m '\000'; } in
-      Pervasives.really_input c result.content 0 n;
-      ignore @@ Pervasives.input c result.after 0 n;
+      Pervasives.really_input c Bytes.(of_string result.content) 0 n;
+      ignore @@ Pervasives.input c Bytes.(of_string result.after) 0 n;
       result
   | `Buf f -> fun c ->
       let buf = Buffer.create 80 in


### PR DESCRIPTION
I wanted to use your package but opam was not able to install it with OCaml 4.06 which has the option safe-strings enable by default.

I don't know if it is the best way to fix that, but I was able to build shcaml with the following changes.

Regards.